### PR TITLE
feat: add language switcher (EN/ES)

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { NavLink, useParams } from 'react-router-dom';
 import { Button } from '../ui-primitives/Button';
 import BrandIcon from '../ui-primitives/icons/BrandIcon';
 import { useTranslation } from 'react-i18next';
+import { LanguageSwitcher } from '../ui-primitives/LanguageSwitcher';
 
 
 const Header: React.FC = () => {
@@ -41,6 +42,7 @@ const Header: React.FC = () => {
           </button>
         </div>
         <div className="Header-right">
+          <LanguageSwitcher />
           <Button to={`/${lang}/contact`} variant="secondary" className="Header-contact-btn">
             {t('btn.contact')}
           </Button>

--- a/src/components/ui-primitives/Button.tsx
+++ b/src/components/ui-primitives/Button.tsx
@@ -6,6 +6,7 @@ interface ButtonProps {
     onClick?: () => void;
     variant?: "primary" | "secondary" | "alternative" | "muted";
     className?: string;
+    disabled?: boolean;
 }
 
 export const Button: React.FC<ButtonProps> = ({
@@ -14,6 +15,8 @@ export const Button: React.FC<ButtonProps> = ({
     onClick,
     variant = "primary",
     className = "",
+    disabled = false,
+
 }) => {
     const classes = `btn btn-${variant}${className ? " " + className : ""}`;
 
@@ -26,7 +29,7 @@ export const Button: React.FC<ButtonProps> = ({
     }
 
     return (
-        <button onClick={onClick} className={classes}>
+        <button onClick={onClick} className={classes} disabled={disabled}>
             {children}
         </button>
     );

--- a/src/components/ui-primitives/LanguageSwitcher.tsx
+++ b/src/components/ui-primitives/LanguageSwitcher.tsx
@@ -1,0 +1,33 @@
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
+import { type SupportedLanguage } from '../../i18n';
+import Button from './Button';
+
+export function LanguageSwitcher() {
+  const { lang } = useParams<{ lang: string }>();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const currentLang = lang as SupportedLanguage;
+
+  const handleChangeLanguage = (newLang: SupportedLanguage) => {
+    if (newLang === currentLang) return;
+
+    const newPath = location.pathname.replace(
+        `/${currentLang}`,
+        `/${newLang}`
+    );
+
+    navigate(newPath);
+  };
+
+  return (
+    <>
+        <div className="language-switcher">
+            <Button variant='muted' onClick={() => handleChangeLanguage("es")} disabled={currentLang === "es"} className={currentLang === "es" ? "active-language" : ""}>ES</Button>
+            {/* <h1>|</h1> */}
+            <Button variant='muted' onClick={() => handleChangeLanguage("en")} disabled={currentLang === "en"} className={currentLang === "en" ? "active-language" : ""}>EN</Button>
+        </div>
+    
+    </>
+  );
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,4 +1,5 @@
 @import "./components/ui-primitives/Button.css";
+@import "./components/ui-primitives/LanguageSwitcher.css";
 @import "./components/ui-patterns/Section.css";
 @import "./components/ui-patterns/Card.css";
 @import "./components/ui-primitives/Stack.module.css";

--- a/src/styles/components/ui-primitives/Button.css
+++ b/src/styles/components/ui-primitives/Button.css
@@ -4,7 +4,7 @@
     padding: var(--btn-padding);
     border-radius: var(--btn-corner-radius);
     font-size: var(--btn-font-size);
-    font-weight: var(--font-weight-medium);;
+    font-weight: var(--font-weight-medium);
     cursor: pointer;
     transition: all 0.3s ease;
     text-decoration: none;
@@ -53,9 +53,13 @@
 .btn-muted {
     background: transparent;
     color: var(--fg);
+    border-color: transparent;
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-normal);
 }
 
 .btn-muted:hover {
     background: var(--btn-bg-muted-hover);
     color: var(--fg-title);
+    
 }

--- a/src/styles/components/ui-primitives/LanguageSwitcher.css
+++ b/src/styles/components/ui-primitives/LanguageSwitcher.css
@@ -1,0 +1,13 @@
+.language-switcher {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    border-radius: var(--btn-corner-radius);
+    border: 1px solid var(--header-bottom-border);
+}
+
+.active-language {
+    color: var(--btn-fg-primary);
+    font-weight: var(--font-weight-medium);
+}

--- a/src/styles/layouts/Header.css
+++ b/src/styles/layouts/Header.css
@@ -64,6 +64,7 @@
     display: flex;
     justify-content: flex-end;
     align-items: center;
+    gap: var(--header-nav-gap);
     
 }
 


### PR DESCRIPTION
## 🧩 Summary

This PR adds a language switcher component to allow users to toggle between English and Spanish.

---

## 🚀 Changes

- Implemented LanguageSwitcher component
- Enabled language switching via route updates (`/es/...` ↔ `/en/...`)
- Preserved current route when switching language
- Added active state styling for current language
- Integrated switcher into header

---

## 🧪 Validation

- Verified correct navigation when switching languages
- Confirmed current route is preserved
- Ensured UI updates correctly without full reload
- Tested both languages across all pages

---

## 📌 Notes

- Language state is controlled via URL (source of truth)
- Persistence will be implemented in a follow-up PR

---

## ✅ Definition of Done

- [x] Language switcher implemented
- [x] Route-aware language switching
- [x] Active language visually indicated
- [x] No navigation regressions

---

## Related issues

Closes #42 