### PR TITLE
feat: add i18n persistence and smart root redirect

### DIFF
--- a/src/i18n/LanguageRouteGuard.tsx
+++ b/src/i18n/LanguageRouteGuard.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 import i18n, { supportedLanguages, type SupportedLanguage } from './index';
 import Layout from '../components/layout/Layout';
+import { setStoredLanguage } from './language';
 
 function isSupportedLanguage(lang: string | undefined): lang is SupportedLanguage {
   return !!lang && supportedLanguages.includes(lang as SupportedLanguage);
@@ -17,6 +18,7 @@ export function LanguageRouteGuard() {
       }
 
       document.documentElement.lang = lang;
+      setStoredLanguage(lang);
     }
   }, [lang]);
 

--- a/src/i18n/RootLanguageRedirect.tsx
+++ b/src/i18n/RootLanguageRedirect.tsx
@@ -1,0 +1,8 @@
+import { Navigate } from 'react-router-dom';
+import { getPreferredLanguage } from './language';
+
+export function RootLanguageRedirect() {
+  const preferredLanguage = getPreferredLanguage();
+
+  return <Navigate to={`/${preferredLanguage}`} replace />;
+}

--- a/src/i18n/language.ts
+++ b/src/i18n/language.ts
@@ -1,0 +1,32 @@
+import { supportedLanguages, type SupportedLanguage } from "./index";
+
+const LANGUAGE_STORAGE_KEY = "lang";
+
+export function isSupportedLanguage(
+  value: string | null | undefined,
+): value is SupportedLanguage {
+  return !!value && supportedLanguages.includes(value as SupportedLanguage);
+}
+
+export function getStoredLanguage(): SupportedLanguage | null {
+  const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+  return isSupportedLanguage(stored) ? stored : null;
+}
+
+export function setStoredLanguage(lang: SupportedLanguage): void {
+  localStorage.setItem(LANGUAGE_STORAGE_KEY, lang);
+}
+
+export function getBrowserLanguage(): SupportedLanguage {
+  const browserLang = navigator.language.toLowerCase();
+
+  if (browserLang.startsWith("es")) {
+    return "es";
+  }
+
+  return "en";
+}
+
+export function getPreferredLanguage(): SupportedLanguage {
+  return getStoredLanguage() ?? getBrowserLanguage();
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,11 +6,12 @@ import VisionPage from "./pages/VisionPage.tsx";
 import PortfolioPage from "./pages/PortfolioPage.tsx";
 import BlogPage from "./pages/BlogPage.tsx";
 import ContactPage from "./pages/ContactPage.tsx";
+import { RootLanguageRedirect } from "./i18n/RootLanguageRedirect.tsx";
 
 export const router = createBrowserRouter([
   {
     path: "/",
-    element: <Navigate to="/en" replace />,
+    element: <RootLanguageRedirect/>,
   },
 
   {
@@ -29,6 +30,6 @@ export const router = createBrowserRouter([
 
   {
     path: "*",
-    element: <Navigate to="/en" replace />,
+    element: <Navigate to="/" replace />,
   },
 ]);


### PR DESCRIPTION
## 🧩 Summary

This PR completes the i18n persistence layer by remembering the user's language choice and applying a smart redirect from the root path.

---

## 🚀 Changes

- Added language persistence using `localStorage`
- Added browser language detection (`navigator.language`) for first-time visits
- Implemented smart redirect from `/` to the preferred language route
- Kept URL as the source of truth for active language
- Updated route guard to persist the active language from the current route

---

## 🧪 Validation

- Verified language preference is preserved across reloads
- Confirmed `/` redirects to stored language when available
- Confirmed first visit falls back to browser language
- Ensured direct navigation to `/es/*` or `/en/*` overrides persisted preference correctly
- Tested navigation and switching across both languages

---

## 📌 Notes

- Persistence is implemented without breaking the routing-based i18n architecture
- URL remains the canonical source of truth
- This completes the initial multilingual support milestone

---

## ✅ Definition of Done

- [x] Selected language is persisted
- [x] Root redirect uses persisted or browser language
- [x] Route guard syncs URL and persisted state
- [x] No regressions in navigation or language switching

---

## Related issues

Closes #43 