### PR TITLE
fix: improve card link styles and scroll restoration

### DIFF
--- a/src/components/routing/ScrollToHash.tsx
+++ b/src/components/routing/ScrollToHash.tsx
@@ -2,10 +2,10 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 const ScrollToHash: React.FC = () => {
-  const { hash } = useLocation();
+  const { hash, pathname } = useLocation();
 
   useEffect(() => {
-    if (!hash) return;
+    if (hash) {
 
     const elementId = hash.replace("#", "");
 
@@ -18,10 +18,18 @@ const ScrollToHash: React.FC = () => {
           block: "start",
         });
       }
-    }, 100);
+    }, 250);
 
     return () => window.clearTimeout(timeoutId);
-  }, [hash]);
+  }
+
+  window.scrollTo({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
+
+  }, [pathname, hash]);
 
   return null;
 };

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from "react-router-dom";
 import FeaturedCaseStudyCard from "../components/domain/FeaturedCaseStudyCard";
 import { homeFeaturedCaseStudies } from "../data/home-featured-case-studies";
+import HybridProfilePhoto from "../assets/images/hybrid-profile/back-d-b.webp";
 
 const HomePage: React.FC = () => {
   const { t } = useTranslation('home');
@@ -96,7 +97,7 @@ const HomePage: React.FC = () => {
             className="stack-60-40-right"
           >
             <div className="image-placeholder-40-60">
-              <img className="image-40-60" src="src/assets/images/hybrid-profile/back-d-b.webp" alt="Hybrid profile illustration" />
+              <img className="image-40-60" src={HybridProfilePhoto} alt="Hybrid profile illustration" />
           
           </div>
           </Stack>

--- a/src/styles/components/domain/ServicePreviewCard.css
+++ b/src/styles/components/domain/ServicePreviewCard.css
@@ -24,6 +24,21 @@
     height: 360px; */
 }
 
+.service-preview-card-link {
+    display: block;
+    height: 100%;
+    color: inherit;
+    text-decoration: none;
+}
+
+.service-preview-card-link:visited,
+.service-preview-card-link:hover,
+.service-preview-card-link:active,
+.service-preview-card-link:focus {
+    color: inherit;
+    text-decoration: none;
+}
+
 .service-preview-card:hover {
     transform: translateY(-6px);
     border-color: var(--accent-1);

--- a/src/styles/pages/CaseStudyPage.css
+++ b/src/styles/pages/CaseStudyPage.css
@@ -76,10 +76,10 @@
     object-position: center center;
 }
 
-.case-study-hero__image.case-study-hero__image--ominira {
+/* .case-study-hero__image.case-study-hero__image--ominira {
     object-fit: fill;
     object-position: center 45%;
-}
+} */
 
 .case-study-hero__image.case-study-hero__image--location-sound {
     object-position: center top;


### PR DESCRIPTION
# fix: improve card link styles and scroll restoration

## Overview

This PR includes patch fixes for the `v2.0.1` release after deploying `v2.0.0`.

## Fixes

- Fixed broken/incorrect image reference.
- Removed default link styling from service/project cards.
- Prevented card links from showing browser default blue color and underline.
- Updated scroll behavior so dynamic case study pages open at the top of the page.
- Preserved hash scrolling behavior for service section links.

## Validation

- [x] Service cards keep custom styling when rendered as links.
- [x] Project cards keep custom styling when rendered as links.
- [x] Case study pages open at the top.
- [x] Service section anchors still scroll correctly.
- [x] Production build passes.