### PR TITLE
fix: update contact page copy for AV systems positioning

### DIFF
--- a/src/i18n/locales/en/contact.json
+++ b/src/i18n/locales/en/contact.json
@@ -1,5 +1,5 @@
 {
-    "contact.title": "Contact",
-    "contact.description": "If you are looking for technical collaboration, backend/frontend development, or service architecture, this is the starting point",
-    "contact.formHeader": "Want to talk?"
+  "contact.title": "Contact",
+  "contact.description": "If you need technical support for an event, AV system, production network or technical infrastructure project, this is the starting point.",
+  "contact.formHeader": "Shall we talk about your project?"
 }

--- a/src/i18n/locales/es/contact.json
+++ b/src/i18n/locales/es/contact.json
@@ -1,5 +1,5 @@
 {
-    "contact.title": "Contacto",
-    "contact.description": "Si buscas colaboración técnica, desarrollo backend/frontend oarquitectura de servicios, este es el punto de partida",
-    "contact.formHeader": "¿Quieres hablar?"
+  "contact.title": "Contacto",
+  "contact.description": "Si necesitas soporte técnico para un evento, sistema AV, red de producción o proyecto de infraestructura técnica, este es el punto de partida.",
+  "contact.formHeader": "¿Hablamos de tu proyecto?"
 }


### PR DESCRIPTION
# v2.0.2 — Contact copy update

Patch release after `v2.0.1`.

## Fixes

- Updated Contact page copy in Spanish and English.
- Replaced outdated backend/frontend-oriented wording.
- Aligned Contact page messaging with the v2.0.0 AV systems portfolio positioning.